### PR TITLE
add utils/vend.sh

### DIFF
--- a/utils/vend.sh
+++ b/utils/vend.sh
@@ -18,7 +18,9 @@ then
     echo "Github CLI could not be found. Install it here: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html"
     exit
 fi
+echo "Checking Github authentication status..."
 gh auth status #returns exit code 1 if user not logged in
+echo ""
 
 # Set variables
 LATESTUPSTREAMHASH=$(git rev-parse '@{u}')
@@ -33,19 +35,28 @@ then
         -f name="$(git rev-parse '@{u}')"
 fi
 
-# Watch execution
-sleep 3
-gh run watch --exit-status # will exit with error code 1 if run fails
+# Define the Vending Machine deploy action
+function watch-action {
+    gh run watch --exit-status # will exit with error code 1 if run fails
 
-# Once run is complete, get the job ID
-echo "Getting job ID"
-RUNJSON=$(gh run list --workflow="$DEPLOYWORKFLOWNAME" \
-    --branch "$CURRENTBRANCHNAME" \
-    --json headSha,databaseId \
-    -q ".[] | select(.headSha == \"$LATESTUPSTREAMHASH\")")
-RUNID=$(echo "$RUNJSON" | jq '.databaseId')
-JOBID=$(gh run view "$RUNID" | grep "gh run view" | awk '{print $11}' | tail -c 11)
+    # Once run is complete, get the job ID
+    echo "Getting job ID"
+    RUNJSON=$(gh run list --workflow="$DEPLOYWORKFLOWNAME" \
+        --branch "$CURRENTBRANCHNAME" \
+        --json headSha,databaseId \
+        -q ".[] | select(.headSha == \"$LATESTUPSTREAMHASH\")")
+    RUNID=$(echo "$RUNJSON" | jq '.databaseId')
+    JOBID=$(gh run view "$RUNID" | grep "gh run view" | awk '{print $11}' | tail -c 11)
 
-# Get the json from the logs of the vending job
-echo "Credentials are:"
-gh run view --log --job "$JOBID" | awk 'BEGIN { first = 7; last = 100 }{ for (i = first; i < last; i++) { printf("%s ", $i) } print $last }' | grep -A11 -B1 "PlayerUserName" | jq
+    # Get the json from the logs of the vending job
+    echo "Credentials are:"
+    gh run view --log --job "$JOBID" | awk 'BEGIN { first = 7; last = 100 }{ for (i = first; i < last; i++) { printf("%s ", $i) } print $last }' | grep -A11 -B1 "PlayerUserName" | jq
+}
+
+# Handle the watch options
+while true; do
+  case "$1" in
+    -w | --watch ) watch-action; exit ;;
+    * ) exit ;;
+  esac
+done


### PR DESCRIPTION
# Pillar
- [ ] **Cloud One**

- [ ] **Vision One**

- [x] **Platform**

## Service

Tooling

## Proposed Changes
  - Adds `utils/vend.sh`, a way to run the [Vending Machine test](https://github.com/deep-security/tdc-2022-techday-2#create-a-new-environment-from-your-last-commit=) against the current branch's latest upstream commit hash.
  - With the `-w` or `--watch` flags, the user can watch the action's execution in the terminal and receive the vending machine creds. 
  - Leverages the Github CLI and JQ. These dependencies are checked at runtime.
