### PR TITLE
Add SSM parameter RoleArn and PortfolioId.

### DIFF
--- a/templates/service_catalog_portfolio.template.yaml
+++ b/templates/service_catalog_portfolio.template.yaml
@@ -36,6 +36,19 @@ Resources:
       PrincipalARN: !Ref GroupAssociationPrincipalArn
       PrincipalType: "IAM"
 
+  PortfolioId:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Value: !Ref PlayerServiceCatalogPortfolio
+      Type: String
+      Name: "PortfolioId"
+  RoleArn:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Value: !GetAtt ServiceCatalogLaunchRole.Arn
+      Type: String
+      Name: "RoleArn"
+
 Outputs:
   PlayerServiceCatalogPortfolio:
     Value: !Ref PlayerServiceCatalogPortfolio


### PR DESCRIPTION
# Pillar
- [ x] **Cloud One**

- [ ] **Vision One**

- [ ] **Platform**

## Service

Service Catalog

## Proposed Changes
  - Adding SSM parameter PortfolioId and RoleArn.  They need to be created here because they need to be used when the player runs the c1 onboarding see challenges/onboarding/templates/c1-onboarding-service-catalog.child-template.yaml
