### PR TITLE
fix copyzips example template

### DIFF
--- a/utils/copyzips/sample-usage.template.yaml
+++ b/utils/copyzips/sample-usage.template.yaml
@@ -39,7 +39,7 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Properties:
       Parameters:
-        SourceBucket: QSS3BucketName
+        SourceBucket: !Ref QSS3BucketName
       TemplateURL: !Sub 'https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}utils/copyzips/copyzips.template.yaml'
       TimeoutInMinutes: 10
 


### PR DESCRIPTION
The copyzips example template had an error where it used the string "QSS3BucketName" instead of a parameter reference. Was confusing, so made this quick fix.
