### PR TITLE
C1CS - Increase Timeouts

### DIFF
--- a/challenges/container_security/lambda/c1cs-day1task1.yaml
+++ b/challenges/container_security/lambda/c1cs-day1task1.yaml
@@ -168,7 +168,7 @@ Resources:
           - scoreroleday1task1C1CS
           - Arn
       Runtime: python3.8
-      Timeout: 30
+      Timeout: 60
     DependsOn:
       - scoreroleday1task1C1CS
 Outputs:

--- a/challenges/container_security/lambda/c1cs-day1task2.yaml
+++ b/challenges/container_security/lambda/c1cs-day1task2.yaml
@@ -97,7 +97,7 @@ Resources:
           - scoreroleday1task2C1CS
           - Arn
       Runtime: python3.8
-      Timeout: 30
+      Timeout: 60
     DependsOn:
       - scoreroleday1task2C1CS
 Outputs:

--- a/challenges/container_security/lambda/c1cs-day1task3.yaml
+++ b/challenges/container_security/lambda/c1cs-day1task3.yaml
@@ -168,7 +168,7 @@ Resources:
           - scoreroleday1task3C1CS
           - Arn
       Runtime: python3.8
-      Timeout: 30
+      Timeout: 60
     DependsOn:
       - scoreroleday1task3C1CS
 Outputs:

--- a/challenges/container_security/lambda/c1cs-day1task4.yaml
+++ b/challenges/container_security/lambda/c1cs-day1task4.yaml
@@ -97,7 +97,7 @@ Resources:
           - scoreroleday1task4C1CS
           - Arn
       Runtime: python3.8
-      Timeout: 30
+      Timeout: 60
     DependsOn:
       - scoreroleday1task4C1CS
 Outputs:

--- a/challenges/container_security/templates/c1cs_codepipeline.yaml
+++ b/challenges/container_security/templates/c1cs_codepipeline.yaml
@@ -207,7 +207,7 @@ Resources:
         Type: AWS::Lambda::Function
         Properties:
           Runtime: python3.8
-          Timeout: 20
+          Timeout: 60
           Handler: index.lambda_handler
           Role: !GetAtt startCodeBuildRole.Arn
           Code:
@@ -343,5 +343,5 @@ Resources:
     Type: Custom::InvokeStartCodeBuildLambda
     Properties:
       ServiceToken: !GetAtt lambdaFunctionStartCodeBuild.Arn
-      Timeout: 10
+      Timeout: 600
         # The code build process takes about 4.5 minuts.  This timeout could be reduced from 10 minutes if needed.

--- a/challenges/container_security/templates/c1cs_deploy.template.yaml
+++ b/challenges/container_security/templates/c1cs_deploy.template.yaml
@@ -173,7 +173,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Runtime: python3.8
-      Timeout: 20
+      Timeout: 60
       Handler: index.lambda_handler
       Role: !GetAtt c1csLambdaFunctionRole.Arn
       Code:
@@ -226,7 +226,7 @@ Resources:
       Type: AWS::Lambda::Function
       Properties:
         Runtime: python3.8
-        Timeout: 20
+        Timeout: 60
         Handler: index.lambda_handler
         Role: !GetAtt c1csLambdaFunctionRole.Arn
         Code:
@@ -289,7 +289,7 @@ Resources:
       Type: AWS::Lambda::Function
       Properties:
         Runtime: python3.8
-        Timeout: 20
+        Timeout: 60
         Handler: index.lambda_handler
         Role: !GetAtt c1csLambdaFunctionRole.Arn
         Code:
@@ -555,7 +555,7 @@ Resources:
       Type: AWS::Lambda::Function
       Properties:
         Runtime: python3.8
-        Timeout: 20
+        Timeout: 60
         Handler: index.lambda_handler
         Role: !GetAtt c1csLambdaFunctionRole.Arn
         Code:
@@ -610,7 +610,7 @@ Resources:
         Type: AWS::Lambda::Function
         Properties:
           Runtime: python3.8
-          Timeout: 20
+          Timeout: 60
           Handler: index.lambda_handler
           Role: !GetAtt c1csLambdaFunctionRole.Arn
           Code:
@@ -642,7 +642,7 @@ Resources:
       Type: AWS::Lambda::Function
       Properties:
         Runtime: python3.8
-        Timeout: 20
+        Timeout: 60
         Handler: index.lambda_handler
         Role: !GetAtt c1csLambdaFunctionRole.Arn
         Code:
@@ -674,7 +674,7 @@ Resources:
       Type: AWS::Lambda::Function
       Properties:
         Runtime: python3.8
-        Timeout: 20
+        Timeout: 60
         Handler: index.lambda_handler
         Role: !GetAtt c1csLambdaFunctionRole.Arn
         Code:
@@ -706,7 +706,7 @@ Resources:
       Type: AWS::Lambda::Function
       Properties:
         Runtime: python3.8
-        Timeout: 20
+        Timeout: 60
         Handler: index.lambda_handler
         Role: !GetAtt c1csLambdaFunctionRole.Arn
         Code:

--- a/challenges/container_security/templates/c1cs_deploy_attack_container.template.yaml
+++ b/challenges/container_security/templates/c1cs_deploy_attack_container.template.yaml
@@ -202,7 +202,7 @@ Resources:
       Type: AWS::Lambda::Function
       Properties:
         Runtime: python3.8
-        Timeout: 20
+        Timeout: 60
         Handler: index.lambda_handler
         Role: !GetAtt c1csAttackContainerLambdaFunctionRole.Arn
         Code:
@@ -234,7 +234,7 @@ Resources:
       Type: AWS::Lambda::Function
       Properties:
         Runtime: python3.8
-        Timeout: 20
+        Timeout: 60
         Handler: index.lambda_handler
         Role: !GetAtt c1csAttackContainerLambdaFunctionRole.Arn
         Code:

--- a/challenges/container_security/templates/c1cs_invoke_attack_container_state_matchine.template.yaml
+++ b/challenges/container_security/templates/c1cs_invoke_attack_container_state_matchine.template.yaml
@@ -35,7 +35,7 @@ Resources:
       Type: AWS::Lambda::Function
       Properties:
         Runtime: python3.8
-        Timeout: 20
+        Timeout: 60
         Handler: index.lambda_handler
         Role: !GetAtt Deployc1csAttackContainerstateMachineLambdaRole.Arn
         Code:

--- a/challenges/container_security/templates/c1cs_service_catalog.template.yaml
+++ b/challenges/container_security/templates/c1cs_service_catalog.template.yaml
@@ -36,7 +36,7 @@ Resources:
       Type: AWS::Lambda::Function
       Properties:
         Runtime: python3.8
-        Timeout: 20
+        Timeout: 60
         Handler: index.lambda_handler
         Role: !GetAtt LambdaFunctionRoleServiceCatalog.Arn
         Code:
@@ -80,5 +80,5 @@ Resources:
     Type: Custom::DeployC1CSStateMachineLambda
     Properties:
       ServiceToken: !GetAtt lambdaFunctionInvokeDeployC1CSStateMachine.Arn
-      Timeout: 5
+      Timeout: 60
 


### PR DESCRIPTION
# Pillar
- [x ] **Cloud One**

- [ ] **Vision One**

- [ ] **Platform**

## Service

Container Security

## Proposed Changes
  - Increase time outs to at least 60 seconds for all c1cs related resources.
  - Some of these time outs were 5 or 10 which is probably to low.
