### PR TITLE
pass password parameter to ADFS stack

### DIFF
--- a/templates/main.template.yaml
+++ b/templates/main.template.yaml
@@ -108,7 +108,7 @@ Resources:
           VPCID: !GetAtt VPCStack.Outputs.VPCID
           PublicSubnet1ID: !GetAtt VPCStack.Outputs.PublicSubnet1ID
           TechDayAdminUser: !GetAtt PlayerStack.Outputs.PlayerUserName
-          #SafeModeAdministratorPassword: !GetAtt Passwords.Outputs.PlayerPassword
+          SafeModeAdministratorPassword: !GetAtt Passwords.Outputs.PlayerPassword
         TemplateURL:  !Sub 'https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}challenges/adfs_challenge/templates/adfs-main.template.yaml'
       DependsOn:
         - VPCStack


### PR DESCRIPTION
# Pillar
- [ X] **Cloud One**

- [ ] **Vision One**

- [ ] **Platform**

## Service

SAML - Commons

## Proposed Changes
  - use generated player password vs hardcoded
